### PR TITLE
refactor(service): implement URL service interface and dependency inj…

### DIFF
--- a/urlshortener.go
+++ b/urlshortener.go
@@ -37,7 +37,11 @@ func main() {
 		log.Println("Connected to MongoDB")
 
 		// Initialize the URL collection in MongoDB
-		service.InitDatabase(dbClient.GetClient(), cfg.MongoDBName, cfg.MongoCollection)
+		urlService := &service.URLServiceImpl{}
+		urlService.InitDatabase(dbClient.GetClient(), cfg.MongoDBName, cfg.MongoCollection)
+
+		// Set URLServiceInstance to the initialized URLService
+		service.URLServiceInstance = urlService
 	}, func(err error) {
 		log.Fatalf("MongoDB connection error: %v", err)
 	}, func() {


### PR DESCRIPTION
…ection

- Created `URLService` interface to abstract URL management operations (`SaveURL`, `GetURL`, `UpdateURL`, `FindURLByOriginal`) for better modularity and testing.
- Refactored `URLServiceImpl` to implement `URLService` with methods for database operations, replacing direct references to `urlCollection`.
- Updated `urlshortener.go`:
  - Injected `URLServiceInstance` in the main function, allowing `CreateShortURL`, `ResolveURL`, and `ToggleURLState` to interact with the injected service.
  - Ensured `URLServiceInstance` is initialized and assigned to the active service during MongoDB connection.
- Enhanced `MongoDBService` disconnect method to check for existing connections before attempting disconnection, improving resilience.