### PR TITLE
test(service): add unit tests for URL service with mock MongoDB colle…

### DIFF
--- a/internal/service/repository.go
+++ b/internal/service/repository.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"go.mongodb.org/mongo-driver/mongo/options"
 	"time"
 
 	"github.com/reactivex/rxgo/v2"
@@ -11,9 +12,16 @@ import (
 	"urlshortener/pkg/models"
 )
 
+// URLCollectionInterface defines the required methods for URLServiceImpl
+type URLCollectionInterface interface {
+	InsertOne(ctx context.Context, document interface{}, opts ...*options.InsertOneOptions) (*mongo.InsertOneResult, error)
+	FindOne(ctx context.Context, filter interface{}, opts ...*options.FindOneOptions) *mongo.SingleResult
+	UpdateOne(ctx context.Context, filter interface{}, update interface{}, opts ...*options.UpdateOptions) (*mongo.UpdateResult, error)
+}
+
 // URLService defines the operations for managing URLs in the database
 type URLService interface {
-	InitDatabase(client *mongo.Client, dbName, collectionName string) *mongo.Collection
+	InitDatabase(client *mongo.Client, dbName, collectionName string) URLCollectionInterface
 	SaveURL(url models.URL) rxgo.Observable
 	GetURL(shortID string) rxgo.Observable
 	UpdateURL(url models.URL) rxgo.Observable
@@ -22,11 +30,11 @@ type URLService interface {
 
 // URLServiceImpl implements URLService
 type URLServiceImpl struct {
-	UrlCollection *mongo.Collection
+	UrlCollection URLCollectionInterface
 }
 
 // InitDatabase initializes the MongoDB connection and assigns the collection
-func (s *URLServiceImpl) InitDatabase(client *mongo.Client, dbName, collectionName string) *mongo.Collection {
+func (s *URLServiceImpl) InitDatabase(client *mongo.Client, dbName, collectionName string) URLCollectionInterface {
 	s.UrlCollection = client.Database(dbName).Collection(collectionName)
 	return s.UrlCollection
 }

--- a/test/repository_test.go
+++ b/test/repository_test.go
@@ -1,0 +1,102 @@
+package test
+
+import (
+	"context"
+	"go.mongodb.org/mongo-driver/bson"
+	"testing"
+	"urlshortener/internal/service"
+	"urlshortener/pkg/models"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// MockSingleResult simulates a single search result
+type MockSingleResult struct {
+	mock.Mock
+}
+
+func (m *MockSingleResult) Decode(v interface{}) error {
+	args := m.Called(v)
+	return args.Error(0)
+}
+
+// MockCollection mocks URLCollectionInterface
+type MockCollection struct {
+	mock.Mock
+}
+
+func (m *MockCollection) InsertOne(ctx context.Context, document interface{}, opts ...*options.InsertOneOptions) (*mongo.InsertOneResult, error) {
+	args := m.Called(ctx, document)
+	return nil, args.Error(1)
+}
+
+func (m *MockCollection) FindOne(ctx context.Context, filter interface{}, opts ...*options.FindOneOptions) *mongo.SingleResult {
+	args := m.Called(ctx, filter)
+	return args.Get(0).(*mongo.SingleResult)
+}
+
+func (m *MockCollection) UpdateOne(ctx context.Context, filter interface{}, update interface{}, opts ...*options.UpdateOptions) (*mongo.UpdateResult, error) {
+	args := m.Called(ctx, filter, update)
+	return nil, args.Error(1)
+}
+
+// Test for SaveURL method
+func TestSaveURL(t *testing.T) {
+	mockCollection := new(MockCollection)
+	urlService := &service.URLServiceImpl{UrlCollection: mockCollection}
+	testURL := models.URL{ID: "testID", OriginalURL: "https://example.com"}
+
+	// Set up the expectation
+	mockCollection.On("InsertOne", mock.Anything, testURL).Return(nil, nil)
+
+	// Call SaveURL and observe the result
+	observable := urlService.SaveURL(testURL)
+	item := <-observable.Observe()
+
+	assert.NoError(t, item.E)
+	assert.Equal(t, testURL, item.V.(models.URL))
+	mockCollection.AssertExpectations(t)
+}
+
+// Test for GetURL method
+func TestGetURL(t *testing.T) {
+	mockCollection := new(MockCollection)
+	urlService := &service.URLServiceImpl{UrlCollection: mockCollection}
+
+	// Prepare the expected URL
+	expectedURL := models.URL{ID: "testID", OriginalURL: "https://example.com"}
+
+	// Create a mongo.SingleResult with the expected document
+	reg := bson.NewRegistry()
+	singleResult := mongo.NewSingleResultFromDocument(expectedURL, nil, reg)
+
+	// Simulate FindOne returning the single result
+	mockCollection.On("FindOne", mock.Anything, mock.Anything).Return(singleResult)
+
+	observable := urlService.GetURL("testID")
+	item := <-observable.Observe()
+
+	assert.NoError(t, item.E)
+	assert.Equal(t, expectedURL, item.V.(models.URL))
+	mockCollection.AssertExpectations(t)
+}
+
+// Test for UpdateURL method
+func TestUpdateURL(t *testing.T) {
+	mockCollection := new(MockCollection)
+	urlService := &service.URLServiceImpl{UrlCollection: mockCollection}
+	testURL := models.URL{ID: "testID", OriginalURL: "https://example.com", Enabled: true}
+
+	// Simulate UpdateOne returning a successful result
+	mockCollection.On("UpdateOne", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+
+	observable := urlService.UpdateURL(testURL)
+	item := <-observable.Observe()
+
+	assert.NoError(t, item.E)
+	assert.Equal(t, testURL, item.V.(models.URL))
+	mockCollection.AssertExpectations(t)
+}


### PR DESCRIPTION
…ction

- Enhanced `URLServiceImpl` by defining `URLCollectionInterface` to abstract MongoDB collection operations, improving testability.
- Created `repository_test.go` to test `URLServiceImpl` methods:
  - **`TestSaveURL`**: Verifies `SaveURL` behavior using a mocked insert operation.
  - **`TestGetURL`**: Tests `GetURL` method with mocked retrieval of a single URL.
  - **`TestUpdateURL`**: Ensures `UpdateURL` properly updates the URL document in the mocked collection.
- Used `testify/mock` to simulate MongoDB operations, ensuring independent and reliable unit tests.