### PR TITLE
chore(config): update MongoDB and Redis addresses for containerized e…

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,10 +11,10 @@ import (
 func LoadConfig() *models.Config {
 	config := &models.Config{
 		Port:            getEnv("PORT", "8080"),
-		MongoURI:        getEnv("MONGO_URI", "mongodb://localhost:27017"),
+		MongoURI:        getEnv("MONGO_URI", "mongodb://mongo:27017"), // Change localhost to mongo
 		MongoDBName:     getEnv("MONGO_DB_NAME", "urlshortener"),
 		MongoCollection: getEnv("MONGO_COLLECTION", "urls"),
-		RedisAddress:    getEnv("REDIS_ADDRESS", "localhost:6379"),
+		RedisAddress:    getEnv("REDIS_ADDRESS", "redis:6379"),
 		RedisPassword:   getEnv("REDIS_PASSWORD", ""), // No password by default
 		RedisDB:         getEnvAsInt("REDIS_DB", 0),
 	}


### PR DESCRIPTION
…nvironment

- Modified `MongoURI` in `config.go` to use `mongodb://mongo:27017` instead of `localhost` to enable inter-container communication.
- Updated `RedisAddress` to `redis:6379` to support Docker network resolution.