### PR TITLE
docs(readme): update README to Spanish and add Swagger API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,84 +1,91 @@
+# Documentación del Proyecto Acortador de URLs
 
-# URL Shortener Project Documentation
-
-This project is a URL Shortener API designed to handle high traffic and provide near real-time statistics. The project utilizes a modern tech stack, reactive programming, and cloud infrastructure to meet performance and scalability requirements.
-
----
-
-## Table of Contents
-1. [Project Overview](#project-overview)
-2. [Tech Stack](#tech-stack)
-3. [Architecture](#architecture)
-4. [Setup Instructions](#setup-instructions)
-5. [Configuration and Environment](#configuration-and-environment)
-6. [Running Locally with Docker Compose](#running-locally-with-docker-compose)
-7. [Deploying on GCloud EC2](#deploying-on-gcloud-ec2)
+Este proyecto es una API para acortar URLs diseñada para manejar tráfico alto y proporcionar estadísticas casi en tiempo
+real. Utiliza una arquitectura moderna, programación reactiva y se despliega en Google Cloud Platform para cumplir con
+los requisitos de rendimiento y escalabilidad.
 
 ---
 
-## Project Overview
+## Tabla de Contenidos
 
-This project implements a URL shortening service similar to goo.gl or bit.ly, with additional functionalities:
-- Near real-time access statistics
-- Ability to enable/disable or modify shortened URLs
-- Support for high traffic, handling up to 1M RPM
-- API REST with approximately 5000 RPM capacity, deployable on cloud infrastructure
-
-## Tech Stack
-
-- **Backend Language**: Go
-- **Database**: MongoDB (public, no authentication)
-- **Cache**: Redis (in-memory cache without authentication)
-- **Cloud Infrastructure**: Google Cloud Platform (GCloud) and AWS EC2
-- **Reactive Programming**: Using `rxgo` to handle non-blocking, concurrent operations
-- **Containerization**: Docker & Docker Compose for local development
-
-## Architecture
-
-### Key Components:
-1. **MongoDB**: Used to store URL information persistently. Exposed publicly on port `27017` without authentication (for testing purposes).
-2. **Redis**: Acts as a cache layer to store frequently accessed URLs, improving response time and reducing database load.
-3. **Reactive Programming**:
-    - Using `rxgo` for non-blocking operations, such as creating and retrieving shortened URLs, caching, and managing statistics in real-time.
-    - Reactive programming improves scalability and performance under heavy load.
-4. **API Layer**: Provides RESTful endpoints for URL management, access, and real-time statistics.
-
-### System Flow:
-1. User accesses or creates a shortened URL.
-2. Service processes the request reactively, updating Redis and MongoDB as necessary.
-3. Real-time statistics are gathered to provide insight into API usage patterns.
+1. [Resumen del Proyecto](#resumen-del-proyecto)
+2. [Pila Tecnológica](#pila-tecnológica)
+3. [Arquitectura](#arquitectura)
+4. [Instrucciones de Configuración](#instrucciones-de-configuración)
+5. [Configuración y Entorno](#configuración-y-entorno)
+6. [Ejecución Local con Docker Compose](#ejecución-local-con-docker-compose)
+7. [Despliegue en Google Cloud](#despliegue-en-google-cloud)
+8. [Swagger API Documentation](#swagger-api-documentation)
 
 ---
 
-## Setup Instructions
+## Resumen del Proyecto
 
-### Prerequisites
-1. **Google Cloud SDK** and **AWS CLI** for managing cloud services.
-2. **Docker** and **Docker Compose** for local development.
-3. **Go** for backend development.
-4. **rxgo** package for reactive programming (`go get -u github.com/reactivex/rxgo/v2`).
+Este servicio de acortamiento de URLs incluye funcionalidades adicionales:
+
+- Estadísticas de acceso en tiempo real
+- Capacidad para habilitar/deshabilitar o modificar URLs acortadas
+- Soporte para tráfico alto, manejando hasta 1M RPM
+- API REST capaz de manejar aproximadamente 5000 RPM, desplegada en infraestructura en la nube
+
+## Pila Tecnológica
+
+- **Backend**: Go
+- **Base de Datos**: MongoDB (pública, sin autenticación para pruebas)
+- **Cache**: Redis (memoria caché sin autenticación)
+- **Infraestructura en la Nube**: Google Cloud Platform (GCP) con tipo de máquina `e2-standard-4`
+- **Programación Reactiva**: `rxgo` para operaciones concurrentes y no bloqueantes
+- **Contenerización**: Docker y Docker Compose para desarrollo local
+
+## Arquitectura
+
+### Componentes Clave:
+
+1. **MongoDB**: Almacena de manera persistente la información de URLs.
+2. **Redis**: Actúa como capa de caché para URLs de acceso frecuente, mejorando el tiempo de respuesta y reduciendo la
+   carga en la base de datos.
+3. **Programación Reactiva**:
+    - Usando `rxgo` para operaciones no bloqueantes en la creación, obtención de URLs, caché y estadísticas en tiempo
+      real.
+    - Mejora la escalabilidad y el rendimiento bajo carga intensa.
+4. **Balanceador de Carga Nginx**: Distribuye el tráfico entre las réplicas del servicio, configurado como un proxy
+   inverso.
 
 ---
 
-## Configuration and Environment
+## Instrucciones de Configuración
+
+### Prerrequisitos
+
+1. **Google Cloud SDK** para gestión de servicios en la nube.
+2. **Docker** y **Docker Compose** para desarrollo local.
+3. **Go** para desarrollo backend.
+4. **rxgo** para programación reactiva (`go get -u github.com/reactivex/rxgo/v2`).
+
+---
+
+## Configuración y Entorno
 
 ### MongoDB & Redis
-- MongoDB is configured to run without authentication for this test environment.
-- Redis is configured as a simple cache, also without authentication.
 
-Both services are containerized with Docker Compose for easy setup.
+- MongoDB está configurado sin autenticación para este entorno de pruebas.
+- Redis funciona como caché, también sin autenticación.
 
-### Environment Variables
-- `MONGO_URI`: MongoDB URI, typically `mongodb://localhost:27017` for local testing.
-- `REDIS_ADDRESS`: Redis URI, typically `localhost:6379`.
+Ambos servicios están contenerizados con Docker Compose para facilitar la configuración.
+
+### Variables de Entorno
+
+- `MONGO_URI`: URI de MongoDB, típicamente `mongodb://localhost:27017` para pruebas locales.
+- `REDIS_ADDRESS`: URI de Redis, típicamente `localhost:6379`.
 
 ---
 
-## Running Locally with Docker Compose
+## Ejecución Local con Docker Compose
 
-Use Docker Compose to set up MongoDB and Redis without authentication.
+Para iniciar MongoDB y Redis sin autenticación, utiliza Docker Compose.
 
 ### `docker-compose.yml`
+
 ```yaml
 version: '3.8'
 
@@ -88,107 +95,100 @@ services:
     container_name: mongo
     restart: always
     ports:
-      - "27017:27017" # Expose MongoDB port publicly
+      - "27017:27017"
     volumes:
       - mongo-data:/data/db
-    command: mongod --bind_ip_all --noauth # No authentication, allow public access
 
   redis:
     image: redis:latest
     container_name: redis
     restart: always
     ports:
-      - "6379:6379" # Expose Redis port without password
+      - "6379:6379"
     volumes:
       - redis-data:/data
 
-volumes:
-  mongo-data:
-    driver: local
-  redis-data:
-    driver: local
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - PORT=8080
+      - REDIS_URL=redis:6379
+    depends_on:
+      - mongo
+      - redis
+    deploy:
+      replicas: 20
+      restart_policy:
+        condition: on-failure
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8080" ]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  load_balancer:
+    image: nginx:latest
+    container_name: nginx_lb
+    restart: always
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf
+    depends_on:
+      - app
 ```
 
-### Running Docker Compose
-To start MongoDB and Redis, run:
+Para iniciar el proyecto, ejecuta:
+
 ```bash
 docker-compose up -d
 ```
 
 ---
 
-## Deploying on GCloud EC2
+## Despliegue en Google Cloud
 
-### Step-by-Step Guide
+### Instrucciones para el Despliegue en GCloud
 
-1. **Provision GCloud EC2 Instance**:
-    - Create an EC2 instance on **Google Cloud** with sufficient resources to handle the anticipated load.
-    - Ensure public access to MongoDB and Redis is configured securely using GCloud firewall rules.
+1. **Configurar la Máquina en Google Cloud**:
+    - Usa una máquina tipo `e2-standard-4` en **Google Cloud** para manejar el tráfico previsto.
+    - Configura Google Cloud para habilitar acceso público a los puertos HTTP/HTTPS y MongoDB.
 
-2. **Set Up Environment**:
-    - SSH into the instance and install **Docker** and **Docker Compose**.
-    - Clone the project repository and navigate to the project directory:
+2. **Configurar el Entorno**:
+    - SSH en la instancia y asegura la instalación de **Docker** y **Docker Compose**.
+    - Clona el repositorio del proyecto y navega al directorio:
       ```bash
-      git clone https://github.com/yourusername/urlshortener.git
+      git clone https://github.com/tuusuario/urlshortener.git
       cd urlshortener
       ```
 
-3. **Deploy Docker Containers**:
-    - Start MongoDB and Redis using Docker Compose:
+3. **Desplegar Contenedores**:
+    - Usa Docker Compose para iniciar MongoDB, Redis y las réplicas del servicio:
       ```bash
       docker-compose up -d
       ```
 
-4. **Run the API**:
-    - Build and start the Go API:
-      ```bash
-      go build -o urlshortener
-      ./urlshortener
-      ```
-    - Configure the Go API to connect to the MongoDB and Redis instances running on the GCloud instance.
+4. **Exponer el API**:
+    - Configura las reglas de firewall en Google Cloud para aceptar solicitudes HTTP/HTTPS en la instancia.
+    - Nginx actúa como balanceador de carga, distribuyendo el tráfico entrante entre las 20 réplicas configuradas.
 
-5. **Expose API Publicly**:
-    - Set up GCloud firewall rules to allow inbound HTTP/HTTPS requests to the instance.
-    - You can use `ngrok` as an alternative during development for a public-facing endpoint without a complex setup.
-
-6. **Autoscaling**:
-    - Consider configuring **GCloud autoscaling** to add more instances under high traffic if running on a managed instance group.
-
-### Example GCloud CLI Commands
-For provisioning and firewall setup:
-```bash
-gcloud compute instances create urlshortener-instance     --zone=us-central1-a     --machine-type=e2-medium     --tags=http-server,https-server
-
-gcloud compute firewall-rules create allow-http     --allow tcp:80
-
-gcloud compute firewall-rules create allow-https     --allow tcp:443
-```
+5. **Escalabilidad y Autoscaling**:
+    - Configura el autoscaling de Google Cloud para añadir instancias adicionales en caso de alta carga, si usas un
+      grupo de instancias administrado.
 
 ---
 
-## Future Enhancements
+## Swagger API Documentation
 
-To make this application more robust and production-ready, consider the following improvements:
+Para facilitar la documentación y pruebas, este proyecto utiliza un archivo Swagger (`openapi-v1.yaml`) que describe la
+API. Puedes visualizar la documentación de la API con herramientas como Swagger UI o Postman, y acceder a los siguientes
+endpoints principales:
 
-1. **Enhanced Security**:
-    - Secure MongoDB and Redis with authentication, and restrict access to these services.
-    - Use HTTPS for all public endpoints, especially for accessing sensitive APIs.
+- **POST /shorten**: Acorta una URL larga.
+- **GET /{short_url}**: Redirige a la URL original usando el identificador.
+- **GET /stats/{short_url}**: Obtiene estadísticas de acceso para una URL acortada.
+- **GET /system/stats**: Muestra estadísticas de uso del sistema (CPU, memoria, disco).
 
-2. **Database Replication and Caching Strategies**:
-    - Implement MongoDB replica sets to ensure high availability and failover capabilities.
-    - Use a distributed caching system with Redis Cluster for scalability.
-
-3. **Error Handling and Circuit Breaker Patterns**:
-    - Integrate a circuit breaker pattern (e.g., with `go-resiliency`) to manage failures in external services like MongoDB or Redis.
-
-4. **Rate Limiting and DDoS Protection**:
-    - Implement rate limiting to prevent abuse of the API and secure the service from DDoS attacks.
-
-5. **Comprehensive Testing**:
-    - Expand testing to cover edge cases and stress test the API at higher RPMs to ensure resilience.
-
----
-
-By following these steps, you will have a fully functional URL shortener service, capable of handling high loads, scalable with cloud infrastructure, and utilizing reactive programming for optimal performance. This document can serve as both a guide and a reference for maintaining and scaling the service in a real-world environment.
-
---- 
+Para ver la documentación en Swagger UI, apunta a [openapi-v1.yaml](openapi-v1.yaml).


### PR DESCRIPTION
- Translated README content to Spanish for better accessibility.
- Updated project documentation:
  - Expanded sections on architecture, tech stack, and setup instructions.
  - Added instructions for running and deploying with Docker Compose and GCP.
  - Introduced Swagger API documentation section with instructions to access `openapi-v1.yaml` and visualize endpoints in Swagger UI.
- Included key endpoints for URL shortening, redirection, statistics, and system resource monitoring.