### PR TITLE
feat(api): add enable/disable endpoint for shortened URLs and update …

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,24 @@ curl --location 'http://35.224.157.227/84561f'
 
 Esta solicitud redirige al cliente a la URL original.
 
+### Habilitar/Deshabilitar una URL Acortada
+
+```bash
+curl --location --request PATCH 'http://35.224.157.227/84561f' \
+--header 'Content-Type: application/json' \
+--data '{
+    "enabled": true
+}'
+```
+
+**Respuesta:**
+
+```json
+{
+   "success": true
+}
+```
+
 ### Obtener Estadísticas de Acceso para una URL Acortada
 
 ```bash

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -47,6 +47,38 @@ paths:
         '302':
           description: Redirects to the original URL
 
+    patch:
+      summary: Enable or disable the shortened URL
+      description: Updates the status of the shortened URL, enabling or disabling it.
+      parameters:
+        - in: path
+          name: short_url
+          schema:
+            type: string
+          required: true
+          description: The shortened URL identifier.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
+                  example: true
+      responses:
+        '200':
+          description: Update success status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+
   /stats/{short_url}:
     get:
       summary: Get URL access statistics


### PR DESCRIPTION
…documentation

- Updated `openapi-v1.yaml` to define PATCH operation for `/short_url`:
  - Added support for enabling or disabling a shortened URL by updating its `enabled` status.
  - Documented request body and response structure.
- Enhanced `README.md`:
  - Added `curl` example to demonstrate how to enable or disable a shortened URL, with a sample JSON response for clarity.