### PR TITLE
docs(api): update OpenAPI spec with error responses for conflict and …

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -31,6 +31,16 @@ paths:
                   short_url:
                     type: string
                     example: "http://35.224.157.227/84561f"
+        '409':
+          description: Conflict - URL already exists
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "Conflict: URL already exists"
 
   /{short_url}:
     get:
@@ -46,6 +56,16 @@ paths:
       responses:
         '302':
           description: Redirects to the original URL
+        '404':
+          description: Not Found - URL does not exist
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "Not Found: URL does not exist"
 
     patch:
       summary: Enable or disable the shortened URL
@@ -78,6 +98,16 @@ paths:
                   success:
                     type: boolean
                     example: true
+        '404':
+          description: Not Found - URL does not exist
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "Not Found: URL does not exist"
 
   /stats/{short_url}:
     get:
@@ -105,6 +135,16 @@ paths:
                     type: string
                     format: date-time
                     example: "2024-10-26T18:52:06Z"
+        '404':
+          description: Not Found - URL does not exist
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "Not Found: URL does not exist"
 
   /system/stats:
     get:


### PR DESCRIPTION
…not found cases

- Enhanced `openapi-v1.yaml` to document additional HTTP error responses:
  - Added `409 Conflict` response for `/shorten` endpoint when a URL already exists.
  - Included `404 Not Found` responses for `/redirect`, `/patch`, and `/stats` endpoints when a URL is missing.
  - Specified error message format for each response to improve API error handling transparency.