### PR TITLE
chore(nginx): increase keepalive connections to support high load

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -63,7 +63,7 @@ http {
         server app:8080;
         server app:8080;
 
-        keepalive 32;  # Enable keepalive for persistent connections
+        keepalive 64;  # Enable keepalive for persistent connections
     }
 
     server {


### PR DESCRIPTION
- Updated `nginx.conf`:
  - Increased `keepalive` connections from 32 to 64 to improve handling of persistent connections, enhancing load capacity for concurrent users.