### PR TITLE
docs(api, readme): update toggle URL status endpoint documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,11 +228,7 @@ Esta solicitud redirige al cliente a la URL original.
 ### Habilitar/Deshabilitar una URL Acortada
 
 ```bash
-curl --location --request PATCH 'http://35.224.157.227/84561f' \
---header 'Content-Type: application/json' \
---data '{
-    "enabled": true
-}'
+curl --location --request PATCH 'curl --location --request PATCH 'http://35.224.157.227/84561f''
 ```
 
 **Respuesta:**

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -68,8 +68,8 @@ paths:
                     example: "Not Found: URL does not exist"
 
     patch:
-      summary: Enable or disable the shortened URL
-      description: Updates the status of the shortened URL, enabling or disabling it.
+      summary: Toggle the status of the shortened URL
+      description: Toggles the status of the shortened URL, enabling it if disabled and disabling it if enabled.
       parameters:
         - in: path
           name: short_url
@@ -77,16 +77,6 @@ paths:
             type: string
           required: true
           description: The shortened URL identifier.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                enabled:
-                  type: boolean
-                  example: true
       responses:
         '200':
           description: Update success status


### PR DESCRIPTION
- Edited `openapi-v1.yaml`:
  - Modified PATCH endpoint to `toggle` URL status instead of explicitly enabling/disabling.
  - Removed request body requirement to simplify endpoint usage.
- Updated `README.md`:
  - Adjusted `curl` example for PATCH request to reflect toggle functionality without request body.