### PR TITLE
docs(readme): fix curl command syntax for toggle URL status example

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Esta solicitud redirige al cliente a la URL original.
 ### Habilitar/Deshabilitar una URL Acortada
 
 ```bash
-curl --location --request PATCH 'curl --location --request PATCH 'http://35.224.157.227/84561f''
+curl --location --request PATCH 'http://35.224.157.227/84561f'
 ```
 
 **Respuesta:**


### PR DESCRIPTION
- Corrected syntax error in `README.md` for the `curl` example under the toggle URL status section.